### PR TITLE
Remove security from OpenAPI spec

### DIFF
--- a/petstore.oas3.yaml
+++ b/petstore.oas3.yaml
@@ -791,19 +791,6 @@ components:
             "$ref": "#/components/schemas/Pet"
       description: Pet object that needs to be added to the store
       required: true
-  securitySchemes:
-    petstore_auth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: http://petstore.swagger.io/oauth/dialog
-          scopes:
-            write:pets: modify pets in your account
-            read:pets: read your pets
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header
   schemas:
     Order:
       type: object


### PR DESCRIPTION
This makes our example easier, as now we can make a plain HTTP request to Prism (e.g. http://127.0.0.1:4010/pets/123) and get an example response, without needing to provide authorization headers.