### PR TITLE
Add example standalone HTTP proxy server

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,30 @@
+var http = require('http'),
+    httpProxy = require('http-proxy');
+
+//
+// Create a proxy server with custom application logic
+//
+var proxy = httpProxy.createProxyServer({});
+
+// To modify the proxy connection before data is sent, you can listen
+// for the 'proxyReq' event. When the event is fired, you will receive
+// the following arguments:
+// (http.ClientRequest proxyReq, http.IncomingMessage req,
+//  http.ServerResponse res, Object options). This mechanism is useful when
+// you need to modify the proxy request before the proxy connection
+// is made to the target.
+//
+proxy.on('proxyReq', function(proxyReq, req, res, options) {
+  proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');
+});
+
+var server = http.createServer(function(req, res) {
+  // You can define here your custom logic to handle the request
+  // and then proxy the request.
+  proxy.web(req, res, {
+    target: 'http://127.0.0.1:5050'
+  });
+});
+
+console.log("listening on port 5050")
+server.listen(5050);


### PR DESCRIPTION
This is an exact copy of the [stand-alone proxy server with proxy request header re-writing][1] on the [`node-http-proxy` GitHub repo][2].

It's perfect for our use-case, as re-writing headers is exactly what we want to do.

[1]: https://github.com/http-party/node-http-proxy#setup-a-stand-alone-proxy-server-with-proxy-request-header-re-writing
[2]: https://github.com/http-party/node-http-proxy