### PR TITLE
Point the proxy target to Prism

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -22,7 +22,7 @@ var server = http.createServer(function(req, res) {
   // You can define here your custom logic to handle the request
   // and then proxy the request.
   proxy.web(req, res, {
-    target: 'http://127.0.0.1:5050'
+    target: 'http://127.0.0.1:4010'
   });
 });
 


### PR DESCRIPTION
We need to do this, otherwise the Proxy server wouldn't proxy through to the Prism server at all.